### PR TITLE
SWAG-0 filter out non-collaborator reviewers before requesting review

### DIFF
--- a/dist/auto-assign.js
+++ b/dist/auto-assign.js
@@ -28467,6 +28467,7 @@ exports.fetchPullRequestReviewers = fetchPullRequestReviewers;
 exports.validatePullRequest = validatePullRequest;
 exports.fetchConfig = fetchConfig;
 exports.fetchChangedFiles = fetchChangedFiles;
+exports.filterCollaborators = filterCollaborators;
 exports.assignReviewers = assignReviewers;
 exports.updateComment = updateComment;
 exports.getExistingCommentId = getExistingCommentId;
@@ -28677,6 +28678,22 @@ async function fetchChangedFiles({ pr }) {
         changedFiles.push(...responseBody.map((file) => file.filename));
     } while (numberOfFilesInCurrentPage === perPage);
     return changedFiles;
+}
+async function filterCollaborators(reviewers) {
+    const octokit = getMyOctokit();
+    const collaboratorChecks = await Promise.allSettled(reviewers.map((reviewer) => octokit.rest.repos.checkCollaborator({
+        owner: github_1.context.repo.owner,
+        repo: github_1.context.repo.repo,
+        username: reviewer,
+    })));
+    return reviewers.filter((_, index) => {
+        const result = collaboratorChecks[index];
+        if (result.status === 'fulfilled') {
+            return true;
+        }
+        (0, logger_1.warning)(`Reviewer "${reviewers[index]}" is not a collaborator of the repository and will be skipped.`);
+        return false;
+    });
 }
 async function assignReviewers(pr, reviewers) {
     const octokit = getMyOctokit();
@@ -37830,7 +37847,7 @@ module.exports = JSON.parse('[[[0,44],"disallowed_STD3_valid"],[[45,46],"valid"]
 /***/ ((module) => {
 
 "use strict";
-module.exports = JSON.parse('{"name":"pr-automation","version":"1.2.1","description":"GitHub Action that automatically requests review of a pull request based on who creates PR and what files were changed. Automerge PR based on that rules.","scripts":{"build:auto-assign":"ncc build ./src/actions/auto-assign.ts -o dist && mv ./dist/index.js ./dist/auto-assign.js","build:auto-merge":"ncc build ./src/actions/auto-merge.ts -o dist && mv ./dist/index.js ./dist/auto-merge.js","build":"npm run build:auto-assign && npm run build:auto-merge","test":"tsc --noEmit && NODE_ENV=test mocha","lint":"eslint -f unix \\"src/**/*.@(ts|tsx)\\"","lint:fix":"eslint --fix -f unix \\"src/**/*.@(ts|tsx)\\"","prepare":"husky install"},"type":"commonjs","husky":{"hooks":{"pre-commit":"npm run lint && npm run test"}},"keywords":[],"license":"MIT","dependencies":{"@actions/core":"1.10.1","@actions/github":"^4.0.0","@octokit/types":"^5.5.0","@octokit/webhooks":"^7.21.0","joi":"17.12.2","minimatch":"^5.1.0","node-fetch":"2.6.13","node-notifier":">=8.0.1","yaml":"2.3.4"},"devDependencies":{"@ezetech/eslint-config":"3.2.0","@types/chai":"4.3.11","@types/minimatch":"3.0.5","@types/mocha":"^10.0.6","@types/node":"20.11.20","@types/node-fetch":"2.6.11","@typescript-eslint/eslint-plugin":"6.9.1","@typescript-eslint/parser":"6.9.1","@vercel/ncc":"^0.36.1","chai":"4.4.1","eslint":"8.52.0","eslint-config-prettier":"8.5.0","eslint-plugin-filenames-simple":"^0.8.0","eslint-plugin-import":"2.26.0","eslint-plugin-jsx-a11y":"6.5.1","eslint-plugin-more":"1.0.5","eslint-plugin-no-null":"1.0.2","eslint-plugin-no-only-tests":"2.6.0","eslint-plugin-prettier":"5.0.1","eslint-plugin-react":"7.30.1","eslint-plugin-security":"1.5.0","eslint-plugin-spellcheck":"^0.0.20","husky":"9.0.11","mocha":"10.3.0","prettier":"3.2.5","ts-node":"10.9.2","typescript":"5.5.4"}}');
+module.exports = JSON.parse('{"name":"pr-automation","version":"1.2.1","description":"GitHub Action that automatically requests review of a pull request based on who creates PR and what files were changed. Automerge PR based on that rules.","scripts":{"build:auto-assign":"ncc build ./src/actions/auto-assign.ts -o dist && mv ./dist/index.js ./dist/auto-assign.js","build:auto-merge":"ncc build ./src/actions/auto-merge.ts -o dist && mv ./dist/index.js ./dist/auto-merge.js","build":"npm run build:auto-assign && npm run build:auto-merge","test":"tsc --noEmit && NODE_ENV=test mocha","lint":"eslint -f unix \\"src/**/*.@(ts|tsx)\\"","lint:fix":"eslint --fix -f unix \\"src/**/*.@(ts|tsx)\\"","prepare":"husky install"},"type":"commonjs","husky":{"hooks":{"pre-commit":"npm run lint && npm run test"}},"keywords":[],"license":"MIT","dependencies":{"@actions/core":"1.10.1","@actions/github":"^4.0.0","@octokit/types":"^5.5.0","@octokit/webhooks":"^7.21.0","joi":"17.12.2","minimatch":"^5.1.0","node-fetch":"2.6.13","node-notifier":">=8.0.1","yaml":"2.3.4"},"devDependencies":{"@ezetech/eslint-config":"3.2.0","@types/chai":"4.3.11","@types/minimatch":"3.0.5","@types/mocha":"^10.0.6","@types/node":"20.11.20","@types/node-fetch":"2.6.11","@types/sinon":"^21.0.0","@typescript-eslint/eslint-plugin":"6.9.1","@typescript-eslint/parser":"6.9.1","@vercel/ncc":"^0.36.1","chai":"4.4.1","eslint":"8.52.0","eslint-config-prettier":"8.5.0","eslint-plugin-filenames-simple":"^0.8.0","eslint-plugin-import":"2.26.0","eslint-plugin-jsx-a11y":"6.5.1","eslint-plugin-more":"1.0.5","eslint-plugin-no-null":"1.0.2","eslint-plugin-no-only-tests":"2.6.0","eslint-plugin-prettier":"5.0.1","eslint-plugin-react":"7.30.1","eslint-plugin-security":"1.5.0","eslint-plugin-spellcheck":"^0.0.20","husky":"9.0.11","mocha":"10.3.0","prettier":"3.2.5","sinon":"^21.0.2","ts-node":"10.9.2","typescript":"5.5.4"}}');
 
 /***/ })
 
@@ -37961,8 +37978,13 @@ async function run() {
             (0, logger_1.info)(`No reviewers were matched for author ${author}. Terminating the process`);
             return;
         }
-        await github.assignReviewers(pr, reviewersToAssign);
-        (0, logger_1.info)(`Requesting review to ${reviewersToAssign.join(', ')}`);
+        const collaboratorReviewers = await github.filterCollaborators(reviewersToAssign);
+        if (collaboratorReviewers.length === 0) {
+            (0, logger_1.info)(`No valid collaborator reviewers found after filtering. Terminating the process`);
+            return;
+        }
+        await github.assignReviewers(pr, collaboratorReviewers);
+        (0, logger_1.info)(`Requesting review to ${collaboratorReviewers.join(', ')}`);
         const messageId = config.options?.withMessage?.messageId;
         (0, logger_1.debug)(`messageId: ${messageId}`);
         if (messageId) {
@@ -37973,7 +37995,7 @@ async function run() {
                 fileChangesGroups,
                 rulesByCreator: config.rulesByCreator,
                 defaultRules: config.defaultRules,
-                reviewersToAssign,
+                reviewersToAssign: collaboratorReviewers,
             });
             const body = `${messageId}\n\n${message}`;
             if (existingCommentId) {

--- a/dist/auto-merge.js
+++ b/dist/auto-merge.js
@@ -28752,6 +28752,7 @@ exports.fetchPullRequestReviewers = fetchPullRequestReviewers;
 exports.validatePullRequest = validatePullRequest;
 exports.fetchConfig = fetchConfig;
 exports.fetchChangedFiles = fetchChangedFiles;
+exports.filterCollaborators = filterCollaborators;
 exports.assignReviewers = assignReviewers;
 exports.updateComment = updateComment;
 exports.getExistingCommentId = getExistingCommentId;
@@ -28962,6 +28963,22 @@ async function fetchChangedFiles({ pr }) {
         changedFiles.push(...responseBody.map((file) => file.filename));
     } while (numberOfFilesInCurrentPage === perPage);
     return changedFiles;
+}
+async function filterCollaborators(reviewers) {
+    const octokit = getMyOctokit();
+    const collaboratorChecks = await Promise.allSettled(reviewers.map((reviewer) => octokit.rest.repos.checkCollaborator({
+        owner: github_1.context.repo.owner,
+        repo: github_1.context.repo.repo,
+        username: reviewer,
+    })));
+    return reviewers.filter((_, index) => {
+        const result = collaboratorChecks[index];
+        if (result.status === 'fulfilled') {
+            return true;
+        }
+        (0, logger_1.warning)(`Reviewer "${reviewers[index]}" is not a collaborator of the repository and will be skipped.`);
+        return false;
+    });
 }
 async function assignReviewers(pr, reviewers) {
     const octokit = getMyOctokit();
@@ -38188,7 +38205,7 @@ module.exports = JSON.parse('[[[0,44],"disallowed_STD3_valid"],[[45,46],"valid"]
 /***/ ((module) => {
 
 "use strict";
-module.exports = JSON.parse('{"name":"pr-automation","version":"1.2.1","description":"GitHub Action that automatically requests review of a pull request based on who creates PR and what files were changed. Automerge PR based on that rules.","scripts":{"build:auto-assign":"ncc build ./src/actions/auto-assign.ts -o dist && mv ./dist/index.js ./dist/auto-assign.js","build:auto-merge":"ncc build ./src/actions/auto-merge.ts -o dist && mv ./dist/index.js ./dist/auto-merge.js","build":"npm run build:auto-assign && npm run build:auto-merge","test":"tsc --noEmit && NODE_ENV=test mocha","lint":"eslint -f unix \\"src/**/*.@(ts|tsx)\\"","lint:fix":"eslint --fix -f unix \\"src/**/*.@(ts|tsx)\\"","prepare":"husky install"},"type":"commonjs","husky":{"hooks":{"pre-commit":"npm run lint && npm run test"}},"keywords":[],"license":"MIT","dependencies":{"@actions/core":"1.10.1","@actions/github":"^4.0.0","@octokit/types":"^5.5.0","@octokit/webhooks":"^7.21.0","joi":"17.12.2","minimatch":"^5.1.0","node-fetch":"2.6.13","node-notifier":">=8.0.1","yaml":"2.3.4"},"devDependencies":{"@ezetech/eslint-config":"3.2.0","@types/chai":"4.3.11","@types/minimatch":"3.0.5","@types/mocha":"^10.0.6","@types/node":"20.11.20","@types/node-fetch":"2.6.11","@typescript-eslint/eslint-plugin":"6.9.1","@typescript-eslint/parser":"6.9.1","@vercel/ncc":"^0.36.1","chai":"4.4.1","eslint":"8.52.0","eslint-config-prettier":"8.5.0","eslint-plugin-filenames-simple":"^0.8.0","eslint-plugin-import":"2.26.0","eslint-plugin-jsx-a11y":"6.5.1","eslint-plugin-more":"1.0.5","eslint-plugin-no-null":"1.0.2","eslint-plugin-no-only-tests":"2.6.0","eslint-plugin-prettier":"5.0.1","eslint-plugin-react":"7.30.1","eslint-plugin-security":"1.5.0","eslint-plugin-spellcheck":"^0.0.20","husky":"9.0.11","mocha":"10.3.0","prettier":"3.2.5","ts-node":"10.9.2","typescript":"5.5.4"}}');
+module.exports = JSON.parse('{"name":"pr-automation","version":"1.2.1","description":"GitHub Action that automatically requests review of a pull request based on who creates PR and what files were changed. Automerge PR based on that rules.","scripts":{"build:auto-assign":"ncc build ./src/actions/auto-assign.ts -o dist && mv ./dist/index.js ./dist/auto-assign.js","build:auto-merge":"ncc build ./src/actions/auto-merge.ts -o dist && mv ./dist/index.js ./dist/auto-merge.js","build":"npm run build:auto-assign && npm run build:auto-merge","test":"tsc --noEmit && NODE_ENV=test mocha","lint":"eslint -f unix \\"src/**/*.@(ts|tsx)\\"","lint:fix":"eslint --fix -f unix \\"src/**/*.@(ts|tsx)\\"","prepare":"husky install"},"type":"commonjs","husky":{"hooks":{"pre-commit":"npm run lint && npm run test"}},"keywords":[],"license":"MIT","dependencies":{"@actions/core":"1.10.1","@actions/github":"^4.0.0","@octokit/types":"^5.5.0","@octokit/webhooks":"^7.21.0","joi":"17.12.2","minimatch":"^5.1.0","node-fetch":"2.6.13","node-notifier":">=8.0.1","yaml":"2.3.4"},"devDependencies":{"@ezetech/eslint-config":"3.2.0","@types/chai":"4.3.11","@types/minimatch":"3.0.5","@types/mocha":"^10.0.6","@types/node":"20.11.20","@types/node-fetch":"2.6.11","@types/sinon":"^21.0.0","@typescript-eslint/eslint-plugin":"6.9.1","@typescript-eslint/parser":"6.9.1","@vercel/ncc":"^0.36.1","chai":"4.4.1","eslint":"8.52.0","eslint-config-prettier":"8.5.0","eslint-plugin-filenames-simple":"^0.8.0","eslint-plugin-import":"2.26.0","eslint-plugin-jsx-a11y":"6.5.1","eslint-plugin-more":"1.0.5","eslint-plugin-no-null":"1.0.2","eslint-plugin-no-only-tests":"2.6.0","eslint-plugin-prettier":"5.0.1","eslint-plugin-react":"7.30.1","eslint-plugin-security":"1.5.0","eslint-plugin-spellcheck":"^0.0.20","husky":"9.0.11","mocha":"10.3.0","prettier":"3.2.5","sinon":"^21.0.2","ts-node":"10.9.2","typescript":"5.5.4"}}');
 
 /***/ })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pr-automation",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pr-automation",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "1.10.1",
@@ -26,6 +26,7 @@
         "@types/mocha": "^10.0.6",
         "@types/node": "20.11.20",
         "@types/node-fetch": "2.6.11",
+        "@types/sinon": "^21.0.0",
         "@typescript-eslint/eslint-plugin": "6.9.1",
         "@typescript-eslint/parser": "6.9.1",
         "@vercel/ncc": "^0.36.1",
@@ -45,6 +46,7 @@
         "husky": "9.0.11",
         "mocha": "10.3.0",
         "prettier": "3.2.5",
+        "sinon": "^21.0.2",
         "ts-node": "10.9.2",
         "typescript": "5.5.4"
       }
@@ -580,6 +582,43 @@
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.1.1.tgz",
+      "integrity": "sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-9.0.2.tgz",
+      "integrity": "sha512-H/JSxa4GNKZuuU41E3b8Y3tbSEx8y4uq4UH1C56ONQac16HblReJomIvv3Ud7ANQHQmkeSowY49Ij972e/pGxQ==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -656,6 +695,21 @@
       "version": "7.5.7",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.7.tgz",
       "integrity": "sha512-/wdoPq1QqkSj9/QOeKkFquEuPzQbHTWAMPH/PaUMB+JuR31lXhlWXRZ52IpfDYVlDOUBvX09uBrPwxGT1hjNBg==",
+      "dev": true
+    },
+    "node_modules/@types/sinon": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-21.0.0.tgz",
+      "integrity": "sha512-+oHKZ0lTI+WVLxx1IbJDNmReQaIsQJjN2e7UUrJHEeByG7bFeKJYsv1E75JxTQ9QKJDp21bAa/0W2Xo4srsDnw==",
+      "dev": true,
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.1.tgz",
+      "integrity": "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3945,6 +3999,32 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sinon": {
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-21.0.2.tgz",
+      "integrity": "sha512-VHV4UaoxIe5jrMd89Y9duI76T5g3Lp+ET+ctLhLDaZtSznDPah1KKpRElbdBV4RwqWSw2vadFiVs9Del7MbVeQ==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^15.1.1",
+        "@sinonjs/samsam": "^9.0.2",
+        "diff": "^8.0.3",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -4637,7 +4717,8 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@ezetech/eslint-config/-/eslint-config-3.2.0.tgz",
       "integrity": "sha512-I6+4roo/x+1/CjxYZV0Ap8orzVcja7biDhRmE6WUVu3YjVo0r9C0QKUSVAC9kpdrXGfoQw8185tL6yc5zFNXkg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@hapi/hoek": {
       "version": "9.3.0",
@@ -4951,6 +5032,42 @@
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
+    "@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.1.1.tgz",
+      "integrity": "sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-9.0.2.tgz",
+      "integrity": "sha512-H/JSxa4GNKZuuU41E3b8Y3tbSEx8y4uq4UH1C56ONQac16HblReJomIvv3Ud7ANQHQmkeSowY49Ij972e/pGxQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^3.0.1",
+        "type-detect": "^4.1.0"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+          "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+          "dev": true
+        }
+      }
+    },
     "@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -5027,6 +5144,21 @@
       "version": "7.5.7",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.7.tgz",
       "integrity": "sha512-/wdoPq1QqkSj9/QOeKkFquEuPzQbHTWAMPH/PaUMB+JuR31lXhlWXRZ52IpfDYVlDOUBvX09uBrPwxGT1hjNBg==",
+      "dev": true
+    },
+    "@types/sinon": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-21.0.0.tgz",
+      "integrity": "sha512-+oHKZ0lTI+WVLxx1IbJDNmReQaIsQJjN2e7UUrJHEeByG7bFeKJYsv1E75JxTQ9QKJDp21bAa/0W2Xo4srsDnw==",
+      "dev": true,
+      "requires": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "@types/sinonjs__fake-timers": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.1.tgz",
+      "integrity": "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -5151,7 +5283,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -5744,7 +5877,8 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.3.7",
@@ -5908,13 +6042,15 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/eslint-plugin-more/-/eslint-plugin-more-1.0.5.tgz",
       "integrity": "sha512-zjDza5jeNBHWf8ZezyW2Llk99abndcGlSz9GIKgVOGwISx0m+f4QoZAapjSmUjKSxHvmOa7Lt68Pk8XbRzWb7w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-no-null": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-no-null/-/eslint-plugin-no-null-1.0.2.tgz",
       "integrity": "sha512-uRDiz88zCO/2rzGfgG15DBjNsgwWtWiSo4Ezy7zzajUgpnFIqd1TjepKeRmJZHEfBGu58o2a8S0D7vglvvhkVA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-no-only-tests": {
       "version": "2.6.0",
@@ -7377,6 +7513,27 @@
         "object-inspect": "^1.9.0"
       }
     },
+    "sinon": {
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-21.0.2.tgz",
+      "integrity": "sha512-VHV4UaoxIe5jrMd89Y9duI76T5g3Lp+ET+ctLhLDaZtSznDPah1KKpRElbdBV4RwqWSw2vadFiVs9Del7MbVeQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^15.1.1",
+        "@sinonjs/samsam": "^9.0.2",
+        "diff": "^8.0.3",
+        "supports-color": "^7.2.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+          "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+          "dev": true
+        }
+      }
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -7510,7 +7667,8 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.2.1.tgz",
       "integrity": "sha512-RIYA36cJn2WiH9Hy77hdF9r7oEwxAtB/TS9/S4Qd90Ap4z5FSiin5zEiTL44OII1Y3IIlEvxwxFUVgrHSZ/UpA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ts-node": {
       "version": "10.9.2",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/mocha": "^10.0.6",
     "@types/node": "20.11.20",
     "@types/node-fetch": "2.6.11",
+    "@types/sinon": "^21.0.0",
     "@typescript-eslint/eslint-plugin": "6.9.1",
     "@typescript-eslint/parser": "6.9.1",
     "@vercel/ncc": "^0.36.1",
@@ -56,6 +57,7 @@
     "husky": "9.0.11",
     "mocha": "10.3.0",
     "prettier": "3.2.5",
+    "sinon": "^21.0.2",
     "ts-node": "10.9.2",
     "typescript": "5.5.4"
   }

--- a/src/actions/auto-assign.ts
+++ b/src/actions/auto-assign.ts
@@ -109,9 +109,16 @@ export async function run(): Promise<void> {
       info(`No reviewers were matched for author ${author}. Terminating the process`);
       return;
     }
-    await github.assignReviewers(pr, reviewersToAssign);
 
-    info(`Requesting review to ${reviewersToAssign.join(', ')}`);
+    const collaboratorReviewers = await github.filterCollaborators(reviewersToAssign);
+    if (collaboratorReviewers.length === 0) {
+      info(`No valid collaborator reviewers found after filtering. Terminating the process`);
+      return;
+    }
+
+    await github.assignReviewers(pr, collaboratorReviewers);
+
+    info(`Requesting review to ${collaboratorReviewers.join(', ')}`);
 
     const messageId = config.options?.withMessage?.messageId;
     debug(`messageId: ${messageId}`);
@@ -123,7 +130,7 @@ export async function run(): Promise<void> {
         fileChangesGroups,
         rulesByCreator: config.rulesByCreator,
         defaultRules: config.defaultRules,
-        reviewersToAssign,
+        reviewersToAssign: collaboratorReviewers,
       });
       const body = `${messageId}\n\n${message}`;
       if (existingCommentId) {

--- a/src/github.spec.ts
+++ b/src/github.spec.ts
@@ -1,0 +1,96 @@
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import * as actionsCore from '@actions/core';
+import * as actionsGithub from '@actions/github';
+import * as logger from './logger';
+
+describe('filterCollaborators', () => {
+  let getInputStub: sinon.SinonStub;
+  let getOctokitStub: sinon.SinonStub;
+  let checkCollaboratorStub: sinon.SinonStub;
+  let warningStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    getInputStub = sinon.stub(actionsCore, 'getInput').returns('fake-token');
+    warningStub = sinon.stub(logger, 'warning');
+
+    checkCollaboratorStub = sinon.stub();
+
+    const octokitMock = {
+      rest: {
+        repos: {
+          checkCollaborator: checkCollaboratorStub,
+        },
+      },
+    };
+
+    getOctokitStub = sinon.stub(actionsGithub, 'getOctokit').returns(octokitMock as any);
+
+    sinon.stub(actionsGithub.context, 'repo').value({ owner: 'test-owner', repo: 'test-repo' });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should return all reviewers when all are collaborators', async () => {
+    checkCollaboratorStub.resolves({ status: 204 });
+
+    const { filterCollaborators } = await import('./github');
+    const result = await filterCollaborators(['alice', 'bob', 'charlie']);
+
+    expect(result).to.deep.equal(['alice', 'bob', 'charlie']);
+  });
+
+  it('should filter out non-collaborators', async () => {
+    checkCollaboratorStub.withArgs(sinon.match({ username: 'alice' })).resolves({ status: 204 });
+    checkCollaboratorStub.withArgs(sinon.match({ username: 'bob' })).rejects(new Error('Not a collaborator'));
+    checkCollaboratorStub.withArgs(sinon.match({ username: 'charlie' })).resolves({ status: 204 });
+
+    const { filterCollaborators } = await import('./github');
+    const result = await filterCollaborators(['alice', 'bob', 'charlie']);
+
+    expect(result).to.deep.equal(['alice', 'charlie']);
+  });
+
+  it('should return empty array when no reviewers are collaborators', async () => {
+    checkCollaboratorStub.rejects(new Error('Not a collaborator'));
+
+    const { filterCollaborators } = await import('./github');
+    const result = await filterCollaborators(['alice', 'bob']);
+
+    expect(result).to.deep.equal([]);
+  });
+
+  it('should return empty array when given empty reviewers list', async () => {
+    const { filterCollaborators } = await import('./github');
+    const result = await filterCollaborators([]);
+
+    expect(result).to.deep.equal([]);
+    expect(checkCollaboratorStub.callCount).to.equal(0);
+  });
+
+  it('should log a warning for each non-collaborator', async () => {
+    checkCollaboratorStub.withArgs(sinon.match({ username: 'alice' })).resolves({ status: 204 });
+    checkCollaboratorStub.withArgs(sinon.match({ username: 'bob' })).rejects(new Error('Not a collaborator'));
+
+    const { filterCollaborators } = await import('./github');
+    await filterCollaborators(['alice', 'bob']);
+
+    expect(warningStub.calledOnce).to.be.true;
+    expect(warningStub.firstCall.args[0]).to.include('bob');
+  });
+
+  it('should call checkCollaborator with correct owner, repo and username', async () => {
+    checkCollaboratorStub.resolves({ status: 204 });
+
+    const { filterCollaborators } = await import('./github');
+    await filterCollaborators(['alice']);
+
+    expect(checkCollaboratorStub.calledOnceWith({
+      owner: 'test-owner',
+      repo: 'test-repo',
+      username: 'alice',
+    })).to.be.true;
+  });
+});

--- a/src/github.ts
+++ b/src/github.ts
@@ -263,6 +263,30 @@ export async function fetchChangedFiles({ pr }: { pr: IPullRequest }): Promise<s
   return changedFiles;
 }
 
+export async function filterCollaborators(reviewers: string[]): Promise<string[]> {
+  const octokit = getMyOctokit();
+  const collaboratorChecks = await Promise.allSettled(
+    reviewers.map((reviewer) =>
+      octokit.rest.repos.checkCollaborator({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        username: reviewer,
+      }),
+    ),
+  );
+
+  return reviewers.filter((_, index) => {
+    const result = collaboratorChecks[index];
+    if (result.status === 'fulfilled') {
+      return true;
+    }
+    warning(
+      `Reviewer "${reviewers[index]}" is not a collaborator of the repository and will be skipped.`,
+    );
+    return false;
+  });
+}
+
 export async function assignReviewers(
   pr: IPullRequest,
   reviewers: string[],


### PR DESCRIPTION
## Summary
- Adds `filterCollaborators()` to `github.ts` that calls `checkCollaborator` for each candidate reviewer in parallel
- Filters out any reviewer who is not a collaborator of the repo before requesting reviews
- Logs a warning for skipped reviewers and exits early if no valid collaborators remain

## Test plan
- [ ] Verify that a PR with all valid collaborator reviewers still gets them assigned
- [ ] Verify that a PR with a non-collaborator in the reviewer list skips that user and assigns the rest
- [ ] Verify that a warning is logged for each skipped non-collaborator
- [ ] Verify that the action exits gracefully if all reviewers are filtered out

Resolves #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)