### PR TITLE
SWAG-0 fix over-filtering of org members as reviewers

### DIFF
--- a/dist/auto-assign.js
+++ b/dist/auto-assign.js
@@ -28467,7 +28467,6 @@ exports.fetchPullRequestReviewers = fetchPullRequestReviewers;
 exports.validatePullRequest = validatePullRequest;
 exports.fetchConfig = fetchConfig;
 exports.fetchChangedFiles = fetchChangedFiles;
-exports.filterCollaborators = filterCollaborators;
 exports.assignReviewers = assignReviewers;
 exports.updateComment = updateComment;
 exports.getExistingCommentId = getExistingCommentId;
@@ -28679,31 +28678,36 @@ async function fetchChangedFiles({ pr }) {
     } while (numberOfFilesInCurrentPage === perPage);
     return changedFiles;
 }
-async function filterCollaborators(reviewers) {
-    const octokit = getMyOctokit();
-    const collaboratorChecks = await Promise.allSettled(reviewers.map((reviewer) => octokit.rest.repos.checkCollaborator({
-        owner: github_1.context.repo.owner,
-        repo: github_1.context.repo.repo,
-        username: reviewer,
-    })));
-    return reviewers.filter((_, index) => {
-        const result = collaboratorChecks[index];
-        if (result.status === 'fulfilled') {
-            return true;
-        }
-        (0, logger_1.warning)(`Reviewer "${reviewers[index]}" is not a collaborator of the repository and will be skipped.`);
-        return false;
-    });
-}
+const NON_COLLABORATOR_ERROR = 'Reviews may only be requested from collaborators.';
 async function assignReviewers(pr, reviewers) {
     const octokit = getMyOctokit();
-    await octokit.rest.pulls.requestReviewers({
+    try {
+        await octokit.rest.pulls.requestReviewers({
+            owner: github_1.context.repo.owner,
+            repo: github_1.context.repo.repo,
+            pull_number: pr.number,
+            reviewers,
+        });
+        return;
+    }
+    catch (err) {
+        if (!(err instanceof Error) ||
+            !err.message.includes(NON_COLLABORATOR_ERROR)) {
+            throw err;
+        }
+    }
+    // At least one reviewer is not a collaborator — retry one-by-one to skip the bad ones
+    const results = await Promise.allSettled(reviewers.map((reviewer) => octokit.rest.pulls.requestReviewers({
         owner: github_1.context.repo.owner,
         repo: github_1.context.repo.repo,
         pull_number: pr.number,
-        reviewers: reviewers,
+        reviewers: [reviewer],
+    })));
+    results.forEach((result, index) => {
+        if (result.status === 'rejected') {
+            (0, logger_1.warning)(`Reviewer "${reviewers[index]}" is not a collaborator of the repository and will be skipped.`);
+        }
     });
-    return;
 }
 async function updateComment(existingCommentId, body) {
     const octokit = getMyOctokit();
@@ -37978,13 +37982,8 @@ async function run() {
             (0, logger_1.info)(`No reviewers were matched for author ${author}. Terminating the process`);
             return;
         }
-        const collaboratorReviewers = await github.filterCollaborators(reviewersToAssign);
-        if (collaboratorReviewers.length === 0) {
-            (0, logger_1.info)(`No valid collaborator reviewers found after filtering. Terminating the process`);
-            return;
-        }
-        await github.assignReviewers(pr, collaboratorReviewers);
-        (0, logger_1.info)(`Requesting review to ${collaboratorReviewers.join(', ')}`);
+        await github.assignReviewers(pr, reviewersToAssign);
+        (0, logger_1.info)(`Requesting review to ${reviewersToAssign.join(', ')}`);
         const messageId = config.options?.withMessage?.messageId;
         (0, logger_1.debug)(`messageId: ${messageId}`);
         if (messageId) {
@@ -37995,7 +37994,7 @@ async function run() {
                 fileChangesGroups,
                 rulesByCreator: config.rulesByCreator,
                 defaultRules: config.defaultRules,
-                reviewersToAssign: collaboratorReviewers,
+                reviewersToAssign,
             });
             const body = `${messageId}\n\n${message}`;
             if (existingCommentId) {

--- a/dist/auto-merge.js
+++ b/dist/auto-merge.js
@@ -28752,7 +28752,6 @@ exports.fetchPullRequestReviewers = fetchPullRequestReviewers;
 exports.validatePullRequest = validatePullRequest;
 exports.fetchConfig = fetchConfig;
 exports.fetchChangedFiles = fetchChangedFiles;
-exports.filterCollaborators = filterCollaborators;
 exports.assignReviewers = assignReviewers;
 exports.updateComment = updateComment;
 exports.getExistingCommentId = getExistingCommentId;
@@ -28964,31 +28963,36 @@ async function fetchChangedFiles({ pr }) {
     } while (numberOfFilesInCurrentPage === perPage);
     return changedFiles;
 }
-async function filterCollaborators(reviewers) {
-    const octokit = getMyOctokit();
-    const collaboratorChecks = await Promise.allSettled(reviewers.map((reviewer) => octokit.rest.repos.checkCollaborator({
-        owner: github_1.context.repo.owner,
-        repo: github_1.context.repo.repo,
-        username: reviewer,
-    })));
-    return reviewers.filter((_, index) => {
-        const result = collaboratorChecks[index];
-        if (result.status === 'fulfilled') {
-            return true;
-        }
-        (0, logger_1.warning)(`Reviewer "${reviewers[index]}" is not a collaborator of the repository and will be skipped.`);
-        return false;
-    });
-}
+const NON_COLLABORATOR_ERROR = 'Reviews may only be requested from collaborators.';
 async function assignReviewers(pr, reviewers) {
     const octokit = getMyOctokit();
-    await octokit.rest.pulls.requestReviewers({
+    try {
+        await octokit.rest.pulls.requestReviewers({
+            owner: github_1.context.repo.owner,
+            repo: github_1.context.repo.repo,
+            pull_number: pr.number,
+            reviewers,
+        });
+        return;
+    }
+    catch (err) {
+        if (!(err instanceof Error) ||
+            !err.message.includes(NON_COLLABORATOR_ERROR)) {
+            throw err;
+        }
+    }
+    // At least one reviewer is not a collaborator — retry one-by-one to skip the bad ones
+    const results = await Promise.allSettled(reviewers.map((reviewer) => octokit.rest.pulls.requestReviewers({
         owner: github_1.context.repo.owner,
         repo: github_1.context.repo.repo,
         pull_number: pr.number,
-        reviewers: reviewers,
+        reviewers: [reviewer],
+    })));
+    results.forEach((result, index) => {
+        if (result.status === 'rejected') {
+            (0, logger_1.warning)(`Reviewer "${reviewers[index]}" is not a collaborator of the repository and will be skipped.`);
+        }
     });
-    return;
 }
 async function updateComment(existingCommentId, body) {
     const octokit = getMyOctokit();

--- a/src/actions/auto-assign.ts
+++ b/src/actions/auto-assign.ts
@@ -110,15 +110,9 @@ export async function run(): Promise<void> {
       return;
     }
 
-    const collaboratorReviewers = await github.filterCollaborators(reviewersToAssign);
-    if (collaboratorReviewers.length === 0) {
-      info(`No valid collaborator reviewers found after filtering. Terminating the process`);
-      return;
-    }
+    await github.assignReviewers(pr, reviewersToAssign);
 
-    await github.assignReviewers(pr, collaboratorReviewers);
-
-    info(`Requesting review to ${collaboratorReviewers.join(', ')}`);
+    info(`Requesting review to ${reviewersToAssign.join(', ')}`);
 
     const messageId = config.options?.withMessage?.messageId;
     debug(`messageId: ${messageId}`);
@@ -130,7 +124,7 @@ export async function run(): Promise<void> {
         fileChangesGroups,
         rulesByCreator: config.rulesByCreator,
         defaultRules: config.defaultRules,
-        reviewersToAssign: collaboratorReviewers,
+        reviewersToAssign,
       });
       const body = `${messageId}\n\n${message}`;
       if (existingCommentId) {

--- a/src/github.spec.ts
+++ b/src/github.spec.ts
@@ -4,28 +4,35 @@ import * as actionsCore from '@actions/core';
 import * as actionsGithub from '@actions/github';
 import * as logger from './logger';
 
-describe('filterCollaborators', () => {
+describe('assignReviewers', () => {
   let getInputStub: sinon.SinonStub;
-  let getOctokitStub: sinon.SinonStub;
-  let checkCollaboratorStub: sinon.SinonStub;
+  let requestReviewersStub: sinon.SinonStub;
   let warningStub: sinon.SinonStub;
+
+  const pr = {
+    number: 42,
+    author: 'zorin-mv',
+    isDraft: false,
+    isOpen: true,
+    labelNames: [],
+    branchName: 'feature/test',
+    baseBranchName: 'main',
+  };
 
   beforeEach(() => {
     getInputStub = sinon.stub(actionsCore, 'getInput').returns('fake-token');
     warningStub = sinon.stub(logger, 'warning');
-
-    checkCollaboratorStub = sinon.stub();
+    requestReviewersStub = sinon.stub();
 
     const octokitMock = {
       rest: {
-        repos: {
-          checkCollaborator: checkCollaboratorStub,
+        pulls: {
+          requestReviewers: requestReviewersStub,
         },
       },
     };
 
-    getOctokitStub = sinon.stub(actionsGithub, 'getOctokit').returns(octokitMock as any);
-
+    sinon.stub(actionsGithub, 'getOctokit').returns(octokitMock as any);
     sinon.stub(actionsGithub.context, 'repo').value({ owner: 'test-owner', repo: 'test-repo' });
   });
 
@@ -33,64 +40,69 @@ describe('filterCollaborators', () => {
     sinon.restore();
   });
 
-  it('should return all reviewers when all are collaborators', async () => {
-    checkCollaboratorStub.resolves({ status: 204 });
+  it('should request all reviewers in a single call when all are collaborators', async () => {
+    requestReviewersStub.resolves({});
 
-    const { filterCollaborators } = await import('./github');
-    const result = await filterCollaborators(['alice', 'bob', 'charlie']);
+    const { assignReviewers } = await import('./github');
+    await assignReviewers(pr, ['alice', 'bob']);
 
-    expect(result).to.deep.equal(['alice', 'bob', 'charlie']);
+    expect(requestReviewersStub.calledOnce).to.be.true;
+    expect(requestReviewersStub.firstCall.args[0]).to.deep.include({
+      pull_number: 42,
+      reviewers: ['alice', 'bob'],
+    });
   });
 
-  it('should filter out non-collaborators', async () => {
-    checkCollaboratorStub.withArgs(sinon.match({ username: 'alice' })).resolves({ status: 204 });
-    checkCollaboratorStub.withArgs(sinon.match({ username: 'bob' })).rejects(new Error('Not a collaborator'));
-    checkCollaboratorStub.withArgs(sinon.match({ username: 'charlie' })).resolves({ status: 204 });
+  it('should retry one-by-one when batch request fails with non-collaborator error', async () => {
+    const nonCollaboratorError = new Error(
+      'Reviews may only be requested from collaborators. One or more of the users or teams you specified is not a collaborator of the ezetech/test-repo repository.',
+    );
+    requestReviewersStub.onFirstCall().rejects(nonCollaboratorError);
+    requestReviewersStub.onSecondCall().resolves({});  // alice ok
+    requestReviewersStub.onThirdCall().rejects(nonCollaboratorError); // bob not a collaborator
 
-    const { filterCollaborators } = await import('./github');
-    const result = await filterCollaborators(['alice', 'bob', 'charlie']);
+    const { assignReviewers } = await import('./github');
+    await assignReviewers(pr, ['alice', 'bob']);
 
-    expect(result).to.deep.equal(['alice', 'charlie']);
+    expect(requestReviewersStub.callCount).to.equal(3);
   });
 
-  it('should return empty array when no reviewers are collaborators', async () => {
-    checkCollaboratorStub.rejects(new Error('Not a collaborator'));
+  it('should log a warning for each reviewer that fails individually', async () => {
+    const nonCollaboratorError = new Error(
+      'Reviews may only be requested from collaborators.',
+    );
+    requestReviewersStub.onFirstCall().rejects(nonCollaboratorError);
+    requestReviewersStub.onSecondCall().resolves({});
+    requestReviewersStub.onThirdCall().rejects(nonCollaboratorError);
 
-    const { filterCollaborators } = await import('./github');
-    const result = await filterCollaborators(['alice', 'bob']);
-
-    expect(result).to.deep.equal([]);
-  });
-
-  it('should return empty array when given empty reviewers list', async () => {
-    const { filterCollaborators } = await import('./github');
-    const result = await filterCollaborators([]);
-
-    expect(result).to.deep.equal([]);
-    expect(checkCollaboratorStub.callCount).to.equal(0);
-  });
-
-  it('should log a warning for each non-collaborator', async () => {
-    checkCollaboratorStub.withArgs(sinon.match({ username: 'alice' })).resolves({ status: 204 });
-    checkCollaboratorStub.withArgs(sinon.match({ username: 'bob' })).rejects(new Error('Not a collaborator'));
-
-    const { filterCollaborators } = await import('./github');
-    await filterCollaborators(['alice', 'bob']);
+    const { assignReviewers } = await import('./github');
+    await assignReviewers(pr, ['alice', 'bob']);
 
     expect(warningStub.calledOnce).to.be.true;
     expect(warningStub.firstCall.args[0]).to.include('bob');
   });
 
-  it('should call checkCollaborator with correct owner, repo and username', async () => {
-    checkCollaboratorStub.resolves({ status: 204 });
+  it('should rethrow errors unrelated to collaborator check', async () => {
+    const networkError = new Error('Network failure');
+    requestReviewersStub.rejects(networkError);
 
-    const { filterCollaborators } = await import('./github');
-    await filterCollaborators(['alice']);
+    const { assignReviewers } = await import('./github');
+    let thrown: Error | undefined;
+    try {
+      await assignReviewers(pr, ['alice']);
+    } catch (err) {
+      thrown = err as Error;
+    }
+    expect(thrown?.message).to.equal('Network failure');
+  });
 
-    expect(checkCollaboratorStub.calledOnceWith({
-      owner: 'test-owner',
-      repo: 'test-repo',
-      username: 'alice',
-    })).to.be.true;
+  it('should succeed without retry when reviewer list is empty', async () => {
+    requestReviewersStub.resolves({});
+
+    const { assignReviewers } = await import('./github');
+    await assignReviewers(pr, []);
+
+    expect(requestReviewersStub.calledOnce).to.be.true;
+    expect(warningStub.called).to.be.false;
   });
 });

--- a/src/github.ts
+++ b/src/github.ts
@@ -263,42 +263,50 @@ export async function fetchChangedFiles({ pr }: { pr: IPullRequest }): Promise<s
   return changedFiles;
 }
 
-export async function filterCollaborators(reviewers: string[]): Promise<string[]> {
-  const octokit = getMyOctokit();
-  const collaboratorChecks = await Promise.allSettled(
-    reviewers.map((reviewer) =>
-      octokit.rest.repos.checkCollaborator({
-        owner: context.repo.owner,
-        repo: context.repo.repo,
-        username: reviewer,
-      }),
-    ),
-  );
-
-  return reviewers.filter((_, index) => {
-    const result = collaboratorChecks[index];
-    if (result.status === 'fulfilled') {
-      return true;
-    }
-    warning(
-      `Reviewer "${reviewers[index]}" is not a collaborator of the repository and will be skipped.`,
-    );
-    return false;
-  });
-}
+const NON_COLLABORATOR_ERROR = 'Reviews may only be requested from collaborators.';
 
 export async function assignReviewers(
   pr: IPullRequest,
   reviewers: string[],
 ): Promise<void> {
   const octokit = getMyOctokit();
-  await octokit.rest.pulls.requestReviewers({
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    pull_number: pr.number,
-    reviewers: reviewers,
+
+  try {
+    await octokit.rest.pulls.requestReviewers({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      pull_number: pr.number,
+      reviewers,
+    });
+    return;
+  } catch (err) {
+    if (
+      !(err instanceof Error) ||
+      !err.message.includes(NON_COLLABORATOR_ERROR)
+    ) {
+      throw err;
+    }
+  }
+
+  // At least one reviewer is not a collaborator — retry one-by-one to skip the bad ones
+  const results = await Promise.allSettled(
+    reviewers.map((reviewer) =>
+      octokit.rest.pulls.requestReviewers({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        pull_number: pr.number,
+        reviewers: [reviewer],
+      }),
+    ),
+  );
+
+  results.forEach((result, index) => {
+    if (result.status === 'rejected') {
+      warning(
+        `Reviewer "${reviewers[index]}" is not a collaborator of the repository and will be skipped.`,
+      );
+    }
   });
-  return;
 }
 
 export type CreateIssueCommentResponseData =


### PR DESCRIPTION
## Problem

The `filterCollaborators` pre-check introduced in #29 used `checkCollaborator` API which returns 404 for org members who have repo access only via the **org's base permissions** (not through a direct collaborator grant or team assignment). This caused valid reviewers to be incorrectly skipped.

## Solution

Replace the pre-check with a try/retry approach inside `assignReviewers`:
1. Try to assign all reviewers in one batch (fast path — no extra API calls)
2. If GitHub rejects with the "not a collaborator" error, retry each reviewer individually
3. Only truly invalid reviewers are skipped and warned; all others are assigned normally

## Test plan
- [ ] Verify org members with base-permission access are no longer skipped
- [ ] Verify truly invalid users (not in org, no repo access) are still skipped with a warning
- [ ] Verify unrelated errors are still re-thrown

Resolves #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)